### PR TITLE
Fix issue #3.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -37,6 +37,10 @@ class EditXlsx
       if obj.options.dir
         mkdirp.sync obj.name
         continue
+      else
+        dirName = path.dirname(obj.name)
+        if dirName != '.'
+          mkdirp.sync dirName
       @files.push obj.name
       fs.writeFileSync obj.name, obj.asBinary(), opts
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,6 +52,10 @@ EditXlsx = (function() {
       if (obj.options.dir) {
         mkdirp.sync(obj.name);
         continue;
+      } else {
+        // Fix issue #3
+        var dirName = path.dirname(obj.name);
+        if (dirName !== '.') mkdirp.sync(dirName);
       }
       this.files.push(obj.name);
       fs.writeFileSync(obj.name, obj.asBinary(), opts);


### PR DESCRIPTION
Somehow after saving a xlsx file with any contents on it, the result of `new Zip` on `function EditXlsx(xlsxPath)` does not brings the directories so I adapted the code to always create the directories of the listed files.